### PR TITLE
Use object form of mapDispatchToProps

### DIFF
--- a/src/containers/BooksForm.js
+++ b/src/containers/BooksForm.js
@@ -87,8 +87,8 @@ BooksForm.propTypes = {
   createBook: PropTypes.func.isRequired,
 };
 
-const mapDispatchToProps = (dispatch) => ({
-  createBook: (book) => dispatch(createBook(book)),
-});
+const mapDispatchToProps = {
+  createBook,
+};
 
 export default connect(null, mapDispatchToProps)(BooksForm);

--- a/src/containers/BooksList.js
+++ b/src/containers/BooksList.js
@@ -72,10 +72,10 @@ const mapStateToProps = ({ books, filter }) => ({
   filter,
 });
 
-const mapDispatchToProps = (dispatch) => ({
-  removeBook: (book) => dispatch(removeBook(book)),
-  changeFilter: (filter) => dispatch(changeFilter(filter)),
-  getRandomBooks: (categories) => dispatch(getRandomBooks(categories)),
-});
+const mapDispatchToProps = {
+  removeBook,
+  changeFilter,
+  getRandomBooks,
+};
 
 export default connect(mapStateToProps, mapDispatchToProps)(BooksList);


### PR DESCRIPTION
The [recommended](https://react-redux.js.org/using-react-redux/connect-mapdispatch#two-forms-of-mapdispatchtoprops) way to use `mapDispatchToProps` is using the object form.

So, instead of: 

```js
const mapDispatchToProps = (dispatch) => ({
  createBook: (book) => dispatch(createBook(book)),	  createBook,
});
```

We can simplify it by passing an object:

```js
const mapDispatchToProps = {
  createBook
};
```
In the object form, `connect` is going to call `bindActionCreators` with the object used as `mapDispatchToProps`.


